### PR TITLE
Don't build lpass docs, building it requires too much disk space

### DIFF
--- a/keyring.sh
+++ b/keyring.sh
@@ -28,12 +28,11 @@ install_linux() {
     pushd /tmp
     sudo apt-get -y install apt-transport-https
     sudo apt-get update
-    sudo apt-get -y install openssl libcurl3 libxml2 libssl-dev libxml2-dev libcurl4-openssl-dev pinentry-curses xclip asciidoc || { echo "Installation failed. Please try again and if it continues to fail open a github issue."; exit 1; }
+    sudo apt-get -y install openssl libcurl3 libxml2 libssl-dev libxml2-dev libcurl4-openssl-dev pinentry-curses xclip || { echo "Installation failed. Please try again and if it continues to fail open a github issue."; exit 1; }
     git clone https://github.com/lastpass/lastpass-cli.git
     cd lastpass-cli/
     make
     sudo make install
-    sudo make install-doc
     popd
     rm -rf /tmp/lastpass-cli    
 }


### PR DESCRIPTION
@fjakobs @timjrobinson Disabling lpass docs, because disk space:

```
Preparing to unpack .../ruby_1%3a2.1.5+z_all.deb ...
Unpacking ruby (1:2.1.5+z) ...
Selecting previously unselected package tcl8.6.
Preparing to unpack .../tcl8.6_8.6.4+dfsg-2_amd64.deb ...
Unpacking tcl8.6 (8.6.4+dfsg-2) ...
Selecting previously unselected package tcl.
Preparing to unpack .../archives/tcl_8.6.0+8_amd64.deb ...
Unpacking tcl (8.6.0+8) ...
Selecting previously unselected package tex-gyre.
Preparing to unpack .../tex-gyre_20140520-1_all.deb ...
Unpacking tex-gyre (20140520-1) ...
Selecting previously unselected package texlive-font-utils.
Preparing to unpack .../texlive-font-utils_2014.20141024-1_all.deb ...
Unpacking texlive-font-utils (2014.20141024-1) ...
Selecting previously unselected package texlive-fonts-recommended-doc.
Preparing to unpack .../texlive-fonts-recommended-doc_2014.20141024-2_all.deb ...
Unpacking texlive-fonts-recommended-doc (2014.20141024-2) ...
Selecting previously unselected package texlive-latex-base-doc.
Preparing to unpack .../texlive-latex-base-doc_2014.20141024-2_all.deb ...
Unpacking texlive-latex-base-doc (2014.20141024-2) ...
Selecting previously unselected package texlive-latex-extra-doc.
Preparing to unpack .../texlive-latex-extra-doc_2014.20141024-1_all.deb ...
Unpacking texlive-latex-extra-doc (2014.20141024-1) ...
dpkg: error processing archive /var/cache/apt/archives/texlive-latex-extra-doc_2014.20141024-1_all.deb (--unpack):
 cannot copy extracted data for './usr/share/doc/texlive-doc/latex/mandi/mandi.pdf' to '/usr/share/doc/texlive-doc/latex/mandi/mandi.pdf.dpkg-new': failed to write (No space left on device)
dpkg-deb: error: subprocess paste was killed by signal (Broken pipe)
Selecting previously unselected package texlive-latex-recommended-doc.
Preparing to unpack .../texlive-latex-recommended-doc_2014.20141024-2_all.deb ...
Unpacking texlive-latex-recommended-doc (2014.20141024-2) ...
Selecting previously unselected package texlive-pictures-doc.
Preparing to unpack .../texlive-pictures-doc_2014.20141024-2_all.deb ...
Unpacking texlive-pictures-doc (2014.20141024-2) ...
Selecting previously unselected package texlive-pstricks-doc.
Preparing to unpack .../texlive-pstricks-doc_2014.20141024-1_all.deb ...
Unpacking texlive-pstricks-doc (2014.20141024-1) ...
dpkg: error processing archive /var/cache/apt/archives/texlive-pstricks-doc_2014.20141024-1_all.deb (--unpack):
 cannot copy extracted data for './usr/share/doc/texlive-doc/generic/pst-osci/oscilloscope.pdf' to '/usr/share/doc/texlive-doc/generic/pst-osci/oscilloscope.pdf.dpkg-new': failed to write (No space left on device)
```